### PR TITLE
bump dependencies

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,9 +1,10 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-    kotlin("jvm") version "1.9.21" apply false
-    kotlin("plugin.serialization") version "1.9.21" apply false
-    id("org.jetbrains.compose") version "1.5.11" apply false
+    kotlin("jvm") version "2.0.21" apply false
+    kotlin("plugin.serialization") version "2.0.21" apply false
+    id("org.jetbrains.compose") version "1.6.11" apply false
+    id("org.jetbrains.kotlin.plugin.compose") version "2.0.21" apply false
     id("com.vanniktech.maven.publish") version "0.28.0" apply false
     id("org.jetbrains.dokka") version "1.9.20"
 }

--- a/example/build.gradle.kts
+++ b/example/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     kotlin("jvm")
     id("org.jetbrains.compose")
+    id("org.jetbrains.kotlin.plugin.compose")
 }
 
 dependencies {

--- a/example/src/main/kotlin/Main.kt
+++ b/example/src/main/kotlin/Main.kt
@@ -32,7 +32,6 @@ fun main() = singleWindowApplication {
                             download = it.toInt()
                         }
                     }
-                    release(true)
                 },
                 onError = {
                     it?.printStackTrace()

--- a/jcef/build.gradle.kts
+++ b/jcef/build.gradle.kts
@@ -18,7 +18,7 @@ dependencies {
 mavenPublishing {
     publishToMavenCentral(host = SonatypeHost.S01, automaticRelease = true)
     signAllPublications()
-    coordinates("dev.datlag", "jcef", "2024.04.20.2")
+    coordinates("dev.datlag", "jcef", "2024.04.20.3")
 
     pom {
         name.set(project.name)

--- a/kcef/build.gradle.kts
+++ b/kcef/build.gradle.kts
@@ -35,7 +35,7 @@ tasks.dokkaHtmlPartial {
 mavenPublishing {
     publishToMavenCentral(host = SonatypeHost.S01, automaticRelease = true)
     signAllPublications()
-    coordinates("dev.datlag", "kcef", "2024.04.20.2")
+    coordinates("dev.datlag", "kcef", "2024.04.20.3")
 
     pom {
         name.set(project.name)

--- a/kcef/build.gradle.kts
+++ b/kcef/build.gradle.kts
@@ -10,16 +10,16 @@ plugins {
     id("org.jetbrains.dokka")
 }
 
-val ktorVersion = "2.3.10"
+val ktorVersion = "3.0.0"
 
 dependencies {
     api(project(":jcef"))
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.0")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0")
     implementation("io.ktor:ktor-client-core:$ktorVersion")
     implementation("io.ktor:ktor-client-okhttp:$ktorVersion")
     implementation("io.ktor:ktor-client-content-negotiation:$ktorVersion")
     implementation("io.ktor:ktor-serialization-kotlinx-json:$ktorVersion")
-    implementation("org.apache.commons:commons-compress:1.26.1")
+    implementation("org.apache.commons:commons-compress:1.27.1")
     implementation(kotlin("stdlib"))
 }
 

--- a/kcef/src/main/kotlin/dev/datlag/kcef/step/fetch/PackageDownloader.kt
+++ b/kcef/src/main/kotlin/dev/datlag/kcef/step/fetch/PackageDownloader.kt
@@ -50,7 +50,11 @@ internal data object PackageDownloader {
 
         val success = download.client.prepareGet(downloadUrl) {
             onDownload { bytesSentTotal, contentLength ->
-                progress.downloading((bytesSentTotal.toFloat() / contentLength.toFloat()) * 100F)
+                if (contentLength == null) {
+                    progress.downloading(0f)
+                } else {
+                    progress.downloading((bytesSentTotal.toFloat() / (contentLength.toFloat()) * 100F))
+                }
             }
         }.execute { httpResponse ->
             val channel: ByteReadChannel = httpResponse.bodyAsChannel()


### PR DESCRIPTION
Notably now using kotlin 2.0.21 and ktor 3.0.0.

Tested with the example using Ktor 3.0.0 dependencies to ensure it fixes [this](https://github.com/KevinnZou/compose-webview-multiplatform/issues/164).