### PR TITLE
Fix icons in README by using old version as source

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ Please take a look at [JetBrains/JetBrainsRuntime](https://github.com/JetBrains/
 
 | OS | Arch |
 |----|------|
-|![Linux](https://cdn.simpleicons.org/linux/000/fff)    | amd64, aarch64 |
-|![Windows](https://cdn.simpleicons.org/windows/000/fff)| amd64, aarch64 |
-|![MacOS](https://cdn.simpleicons.org/macos/000/fff)    | amd64, aarch64 |
+|![Linux](https://cdn.jsdelivr.net/npm/simple-icons@v12/icons/linux.svg)    | amd64, aarch64 |
+|![Windows](https://cdn.jsdelivr.net/npm/simple-icons@v12/icons/windows.svg)| amd64, aarch64 |
+|![MacOS](https://cdn.jsdelivr.net/npm/simple-icons@v12/icons/macos.svg)    | amd64, aarch64 |
 
 ## Installation
 


### PR DESCRIPTION
The Windows icon has been removed in a recent version of simple icons, but it can still be obtained from older versions of the library on some of the CDNs.